### PR TITLE
Draw reweighted samples without replacement

### DIFF
--- a/src/kde_analysis/m1_dL_twoditerativekde.py
+++ b/src/kde_analysis/m1_dL_twoditerativekde.py
@@ -221,7 +221,8 @@ def get_random_sample(original_samples, bootstrap='poisson'):
     rng = np.random.default_rng()
 
     if bootstrap == 'poisson':
-        random_unweighted_sample = rng.choice(original_samples, np.random.poisson(1))
+        # Do not repeat any PE sample
+        random_unweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False)
     else:
         random_unweighted_sample = rng.choice(original_samples)
     return random_unweighted_sample
@@ -297,7 +298,8 @@ def get_reweighted_sample(original_samples, redshiftvals, pdetvals, fpop_kde, bo
 
     # Perform reweighted sampling based on bootstrap method
     if bootstrap == 'poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), p=fpop_at_samples)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False, p=fpop_at_samples)
     else:
         reweighted_sample = rng.choice(original_samples, p=fpop_at_samples)
 
@@ -380,7 +382,8 @@ def mean_bufferkdelist_reweighted_samples(original_samples, redshiftvals, pdetva
 
     rng = np.random.default_rng()
     if bootstrap_choice =='poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), p=norm_mediankdevals)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False, p=norm_mediankdevals)
     else:
         reweighted_sample = rng.choice(original_samples, p=norm_mediankdevals)
     return reweighted_sample

--- a/src/kde_analysis/spin_m1m2case.py
+++ b/src/kde_analysis/spin_m1m2case.py
@@ -217,7 +217,8 @@ def get_random_sample(original_samples, bootstrap='poisson'):
     """
     rng = np.random.default_rng()
     if bootstrap =='poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1))
+        # Make sure we do not repeat any PE sample, to avoid cross-validation issues
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False)
     else:
         reweighted_sample = rng.choice(original_samples)
     return reweighted_sample
@@ -281,7 +282,8 @@ def get_reweighted_sample(original_samples, redshiftvals, vt_vals, fpop_kde, boo
 
     # Perform resampling with or without Poisson reweighting
     if bootstrap =='poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), p=fpop_at_samples)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False, p=fpop_at_samples)
     else:
         reweighted_sample = rng.choice(original_samples, p=fpop_at_samples)
 
@@ -345,7 +347,8 @@ def New_median_bufferkdelist_reweighted_samples(sample, redshiftvals, vt_vals, m
     rng = np.random.default_rng()
 
     if bootstrap_choice =='poisson':
-        reweighted_sample = rng.choice(sample, np.random.poisson(1), p=norm_mediankdevals)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(sample, np.random.poisson(1), replace=False, p=norm_mediankdevals)
     else:
         reweighted_sample = rng.choice(sample, p=norm_mediankdevals)
     return reweighted_sample

--- a/src/kde_analysis/three_dim_kde.py
+++ b/src/kde_analysis/three_dim_kde.py
@@ -219,7 +219,8 @@ def get_random_sample(original_samples, bootstrap='poisson'):
     """
     rng = np.random.default_rng()
     if bootstrap =='poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1))
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False)
     else:
         reweighted_sample = rng.choice(original_samples)
     return reweighted_sample
@@ -286,7 +287,8 @@ def get_reweighted_sample(original_samples, redshiftvals, pdet_vals, fpop_kde, b
 
     # Perform resampling with or without Poisson reweighting
     if bootstrap =='poisson':
-        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), p=fpop_at_samples)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(original_samples, np.random.poisson(1), replace=False, p=fpop_at_samples)
     else:
         reweighted_sample = rng.choice(original_samples, p=fpop_at_samples)
 
@@ -352,7 +354,8 @@ def New_median_bufferkdelist_reweighted_samples(sample, redshiftvals, pdet_vals,
     rng = np.random.default_rng()
 
     if bootstrap_choice =='poisson':
-        reweighted_sample = rng.choice(sample, np.random.poisson(1), p=norm_mediankdevals)
+        # Do not repeat any PE sample
+        reweighted_sample = rng.choice(sample, np.random.poisson(1), replace=False, p=norm_mediankdevals)
     else:
         reweighted_sample = rng.choice(sample, p=norm_mediankdevals)
     return reweighted_sample


### PR DESCRIPTION
Avoid the same PE sample appearing multiple times in 'Poisson bootstrapping' by drawing without replacement. 
If copies of the exact same point are present in the analysis samples the cross-validation procedure is likely not to work correctly with overfitting of random fluctuations in the PE sample set. 